### PR TITLE
Refactor order retrieval in AlpacaClient to handle multiple statuses

### DIFF
--- a/app/alpaca_client.py
+++ b/app/alpaca_client.py
@@ -708,11 +708,9 @@ class AlpacaClient:
             # Import QueryOrderStatus enum
             from alpaca.trading.enums import QueryOrderStatus
             
-            # Create request with status parameter (required by official docs)
-            request_params = GetOrdersRequest(
-                limit=limit,
-                status=QueryOrderStatus.ALL if status is None else QueryOrderStatus(status.upper())
-            )
+            # Handle multiple statuses - QueryOrderStatus doesn't support comma-separated values
+            # So we need to get all orders and filter manually
+            request_params = GetOrdersRequest(limit=limit)
             orders = self.trading_client.get_orders(filter=request_params)
 
             logger.debug(f"Retrieved {len(orders)} total orders from Alpaca API (status filter: {status})")


### PR DESCRIPTION
- Updated the order request logic to retrieve all orders and filter them manually, as QueryOrderStatus does not support comma-separated values.
- Removed the status parameter from the request creation to streamline the process.

These changes enhance the flexibility of order management by allowing for more comprehensive status handling.

## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes (`pytest tests/ -v`)
- [ ] I have tested with real Alpaca Paper Trading API (if applicable)
- [ ] No mock data was introduced

**Test Results:**
```bash
# Paste your pytest results here
pytest tests/ -v --disable-warnings
```

## API Changes (if applicable)
- [ ] New endpoints added
- [ ] Existing endpoints modified
- [ ] Breaking changes to API responses
- [ ] New request/response models

**New/Modified Endpoints:**
- `GET/POST /api/v1/...` - Description

## Documentation
- [ ] I have updated the README.md
- [ ] I have updated the API documentation
- [ ] Swagger/OpenAPI documentation is up to date

## Security
- [ ] No API keys or secrets are exposed in code
- [ ] All new code follows security best practices
- [ ] Input validation is implemented where needed

## Code Quality
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new linting warnings
- [ ] All tests are in the `tests/` directory

## Additional Notes
Any additional information or context about the PR.