### PR TITLE
feat: 容器化 opitios_alpaca（Dockerfile + JWT/self-call 加固）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# VCS / CI / tooling
+.git
+.github
+.claude
+.gitattributes
+.gitignore
+
+# Tests & docs
+tests
+docs
+README.md
+README.zh.md
+容器化方案分析.md
+
+# Runtime artifacts
+logs
+*.log
+*.db
+*.sqlite
+*.sqlite3
+*.db-journal
+
+# Secrets - NEVER bake into the image (bind-mount at runtime instead)
+secrets.yml
+secrets.yaml
+*.secret
+.env
+.env.*
+
+# Python environments & caches
+venv
+venv*
+.venv
+env
+__pycache__
+**/__pycache__
+*.py[cod]
+.pytest_cache
+.mypy_cache
+htmlcov
+.coverage
+coverage.xml
+
+# Docker files themselves
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Deploy script (host-side)
+deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# curl is needed for the HEALTHCHECK
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code (secrets.yml is excluded via .dockerignore and must be
+# bind-mounted at runtime: -v /path/to/secrets.yml:/app/secrets.yml:ro)
+COPY . .
+
+# Non-root user; make sure runtime dirs exist and are writable
+RUN useradd --create-home --uid 10001 appuser \
+    && mkdir -p /app/static /app/logs \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8090
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:8090/health || exit 1
+
+# Run uvicorn directly (never `python main.py`, which enables --reload when
+# settings.debug is true). Single worker: the auto-sell loop must not run twice.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8090"]

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -21,13 +21,12 @@ import redis
 from config import settings
 
 
-# JWT配置
-JWT_SECRET = (
-    settings.jwt_secret if hasattr(settings, 'jwt_secret')
-    else "your-secret-key"
-)
-JWT_ALGORITHM = "HS512"
-JWT_EXPIRATION_HOURS = 24
+# JWT配置 —— 统一从 config.settings 读取（config.py 在 secret 缺失时启动即报错）。
+# 算法必须与签发方一致：opitios_service 用 HS512 签发，settings.jwt_algorithm
+# 默认即 HS512，签发与验证两侧读同一配置。
+JWT_SECRET = settings.jwt_secret
+JWT_ALGORITHM = settings.jwt_algorithm
+JWT_EXPIRATION_HOURS = settings.jwt_expiration_hours
 
 # Redis连接 (用于分布式rate limiting)
 redis_client = None

--- a/app/sell_module/api_client.py
+++ b/app/sell_module/api_client.py
@@ -3,6 +3,7 @@ API 客户端
 卖出模块通过 HTTP API 调用获取数据和下单，而不是直接访问连接池
 """
 
+import os
 import aiohttp
 import asyncio
 from typing import List, Dict, Any, Optional
@@ -16,8 +17,12 @@ class AlpacaAPIClient:
     Alpaca API 客户端 - 通过 HTTP 调用内部 API endpoints
     替代直接连接池访问，符合标准架构流程
     """
-    
-    def __init__(self, base_url: str = "http://localhost:8090"):
+
+    def __init__(self, base_url: Optional[str] = None):
+        # Self-call base URL: configurable via env (needed in containers where
+        # the service may not be reachable at localhost:8090)
+        if base_url is None:
+            base_url = os.environ.get("ALPACA_SELF_URL", "http://localhost:8090")
         self.base_url = base_url.rstrip('/')
         self.session = None
         self.headers = {

--- a/config.py
+++ b/config.py
@@ -66,6 +66,14 @@ def load_secrets():
     database_url = yaml_config.get('database', {}).get('url')
     if not database_url:
         raise ValueError("Database URL is required in secrets.yml under 'database.url'")
+
+    # JWT secret is REQUIRED - fail fast instead of silently falling back to a
+    # well-known default secret (previously "CHANGE_THIS_SECRET_KEY_IN_PRODUCTION")
+    if not yaml_config.get('jwt', {}).get('secret_key'):
+        raise ValueError(
+            "JWT secret key is required in secrets.yml under 'jwt.secret_key'. "
+            "Refusing to start without it (no insecure default fallback)."
+        )
     
     # Load accounts from database (REQUIRED)
     try:
@@ -126,8 +134,11 @@ class Settings(BaseSettings):
     log_level: str = secrets.get('app', {}).get('log_level', "INFO")
     
     # JWT Configuration
-    jwt_secret: str = secrets.get('jwt', {}).get('secret_key', "CHANGE_THIS_SECRET_KEY_IN_PRODUCTION")
-    jwt_algorithm: str = secrets.get('jwt', {}).get('algorithm', "HS256")
+    # secret_key presence is validated in load_secrets() (fail-fast, no default).
+    # Default algorithm is HS512 to match the token issuer (opitios_service
+    # signs with HS512; middleware historically verified HS512).
+    jwt_secret: str = secrets['jwt']['secret_key']
+    jwt_algorithm: str = secrets.get('jwt', {}).get('algorithm', "HS512")
     jwt_expiration_hours: int = secrets.get('jwt', {}).get('expiration_hours', 24)
     
     # Redis Configuration


### PR DESCRIPTION
## 概要
将 opitios_alpaca 容器化，并顺带做几处 JWT / self-call 安全加固。

## 改动（纯代码，5 个文件）
- **Dockerfile**（python:3.12-slim，非 root，`/health` healthcheck，纯 uvicorn 无 reload）+ `.dockerignore`
- **config.py**：删除 JWT 密钥的默认回退 `"CHANGE_THIS..."`，缺失时启动即 fail-fast；`jwt_algorithm` 默认对齐实际签发方（HS512）
- **app/middleware.py**：移除自带的 `"your-secret-key"` / 硬编码算法常量，改为统一从 settings 读取（验签与 opitios_service 的签发保持一致）
- **app/sell_module/api_client.py**：自调用地址 `http://localhost:8090` 改为读环境变量 `ALPACA_SELF_URL`

## 本地测试
docker build（956MB）+ 一次性 MySQL 冒烟：容器 health `healthy`，`/health` 正常；CI 同款单测 38 通过、6 安全测试通过。

## 说明
> 部署编排（compose/Caddyfile/迁移方案）**有意不包含在本 PR 中**——那些含基础设施细节，放在私有部署库/本地，不进公开仓库。本 PR 仅为 alpaca 自身的容器化与代码加固。

## 注意
**请勿合并** —— 等 code review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
